### PR TITLE
fix: parse quoted url, set default http:// scheme for url

### DIFF
--- a/src/curl.pest
+++ b/src/curl.pest
@@ -9,7 +9,8 @@ double_quoted = _{ "\"" ~ double_quoted_inner ~ "\"" }
 double_quoted_inner = { (!"\"" ~ ANY)* }
 
 none_ws = { (!ws ~ ANY)+ }
-url = @{ "http" ~ "s"? ~ "://" ~ none_ws }
+url_plain = @{ "http" ~ "s"? ~ "://" ~ none_ws }
+url = { single_quoted | double_quoted | url_plain }
 option = _{ method_option | header_option | body_option | auth_option}
 
 method_option = _{ "-X" ~ ws+ ~ method }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,7 +25,15 @@ fn parse_input(input: &str) -> Result<ParsedRequest> {
                 parsed.method = method;
             }
             Rule::url => {
-                let url = pair.as_str().parse().context(ParseUrlSnafu)?;
+                let url = pair.into_inner().as_str();
+
+                // if empty scheme set curl defaults to HTTP
+                let url = if url.contains("://") {
+                    url.parse().context(ParseUrlSnafu)?
+                } else {
+                    format!("http://{url}").parse().context(ParseUrlSnafu)?
+                };
+
                 parsed.url = url;
             }
             Rule::header => {
@@ -211,6 +219,42 @@ mod tests {
                 "Basic c2tfdGVzdF80ZUMzOUhxTHlqV0Rhcmp0VDF6ZHA3ZGM6"
             ))
         );
+
+        #[cfg(feature = "reqwest")]
+        {
+            let req: reqwest::RequestBuilder = parsed.into();
+            let res = req.send().await?;
+            assert_eq!(res.status(), 200);
+            let _body = res.text().await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_curl_4_should_work() -> Result<()> {
+        let input = r#"curl "https://ifconfig.me/""#;
+
+        let parsed = ParsedRequest::load(input, None::<()>)?;
+        assert_eq!(parsed.method, Method::GET);
+        assert_eq!(parsed.url.to_string(), "https://ifconfig.me/");
+
+        #[cfg(feature = "reqwest")]
+        {
+            let req: reqwest::RequestBuilder = parsed.into();
+            let res = req.send().await?;
+            assert_eq!(res.status(), 200);
+            let _body = res.text().await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_curl_5_should_work() -> Result<()> {
+        let input = r#"curl 'ifconfig.me'"#;
+
+        let parsed = ParsedRequest::load(input, None::<()>)?;
+        assert_eq!(parsed.method, Method::GET);
+        assert_eq!(parsed.url.to_string(), "http://ifconfig.me/");
 
         #[cfg(feature = "reqwest")]
         {


### PR DESCRIPTION
Hi!

This PR allows to parse inputs like this `curl 'ifconfig.me/all'`
 - parse quoted url
 - set default for curl http:// scheme
 
