### PR TITLE
feat(parser): add support for --data-raw option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "curl-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-parser"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/curl-parser"

--- a/src/curl.pest
+++ b/src/curl.pest
@@ -24,7 +24,7 @@ header = { single_quoted | double_quoted | none_ws }
 location_option = _{ ("-L" | "--location") ~ ws+ ~ location }
 location = { single_quoted | double_quoted | none_ws }
 
-body_option = _{ ("-d" | "--data") ~ ws+ ~ body }
+body_option = _{ ("--data-raw" | "--data" | "-d") ~ ws+ ~ body }
 body = { single_quoted | double_quoted | (!((" -" ~ ASCII_ALPHA_UPPER) | (" --" ~ ASCII_ALPHA_LOWER) | "\\") ~ ANY)+ }
 
 auth_option = _{ "-u" ~ ws+ ~ auth }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -321,4 +321,13 @@ mod tests {
         assert_eq!(parsed.body, vec!["{\"-name\":\"--John\",\" --age\":30}"]);
         Ok(())
     }
+
+    #[tokio::test]
+    async fn parse_curl_with_data_raw_should_work() -> Result<()> {
+        let input = r#"curl --location 'https://httpbin.org/post' --header 'Content-Type: application/json' --data-raw '{"name":"John Doe","age":30}'"#;
+        let parsed = ParsedRequest::from_str(input)?;
+        assert_eq!(parsed.method, Method::POST);
+        assert_eq!(parsed.body, vec![r#"{"name":"John Doe","age":30}"#]);
+        Ok(())
+    }
 }


### PR DESCRIPTION
The curl command supports both --data and --data-raw for sending data in POST requests. Added --data-raw to the grammar's body_option rule to ensure compatibility with commonly used curl commands.